### PR TITLE
Improve write_file tool descriptions to inform LLM about directory creation capability

### DIFF
--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -74,7 +74,7 @@ export class WriteFileTool
     super(
       WriteFileTool.Name,
       'WriteFile',
-      `Writes content to a specified file in the local filesystem.
+      `Writes content to a specified file in the local filesystem. If the directory containing the file does not exist, it will be created automatically.
 
       The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
       Icon.Pencil,
@@ -82,7 +82,7 @@ export class WriteFileTool
         properties: {
           file_path: {
             description:
-              "The absolute path to the file to write to (e.g., '/home/user/project/file.txt'). Relative paths are not supported.",
+              "The absolute path to the file to write to (e.g., '/home/user/project/file.txt'). Relative paths are not supported. If the directory does not exist, it will be created automatically.",
             type: Type.STRING,
           },
           content: {


### PR DESCRIPTION
## Summary

This PR improves the `write_file` tool descriptions to better inform the LLM about the tool's directory creation capability, addressing issue google-gemini#5758.

## Changes

- **Tool Description**: Updated to mention that directories are created automatically if they don't exist
- **Parameter Description**: Updated to clarify that the directory will be created automatically

## Problem

The issue google-gemini#5758 reported that users were confused about whether the `write_file` tool could create directories. The tool actually does create directories automatically (as evidenced by the existing test "should create directory if it does not exist"), but this capability wasn't clearly communicated to the LLM through the tool descriptions.

## Solution

Updated the tool schema descriptions to explicitly mention directory creation capability:

**Before:**
```
"Writes content to a specified file in the local filesystem."
"The absolute path to the file to write to (e.g., '/home/user/project/file.txt'). Relative paths are not supported."
```

**After:**
```
"Writes content to a specified file in the local filesystem. If the directory containing the file does not exist, it will be created automatically."
"The absolute path to the file to write to (e.g., '/home/user/project/file.txt'). Relative paths are not supported. If the directory does not exist, it will be created automatically."
```

## Testing

- ✅ All 26 write-file tests pass
- ✅ Directory creation functionality is already tested and working
- ✅ No breaking changes to existing behavior

## Impact

This change helps the LLM understand that it can use the `write_file` tool even when the target directory doesn't exist, reducing user confusion and improving the overall user experience.

Closes google-gemini#5758